### PR TITLE
Added config support via Collective.Config.DuskConfig

### DIFF
--- a/Common/src/main/java/com/natamus/dragondropselytra/ModCommon.java
+++ b/Common/src/main/java/com/natamus/dragondropselytra/ModCommon.java
@@ -1,9 +1,11 @@
 package com.natamus.dragondropselytra;
 
+import com.natamus.dragondropselytra.config.ConfigHandler;
 
 public class ModCommon {
 
 	public static void init() {
+		ConfigHandler.initConfig();
 		load();
 	}
 

--- a/Common/src/main/java/com/natamus/dragondropselytra/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/dragondropselytra/config/ConfigHandler.java
@@ -1,0 +1,22 @@
+package com.natamus.dragondropselytra.config;
+
+import com.natamus.collective.config.DuskConfig;
+import com.natamus.dragondropselytra.util.Reference;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class ConfigHandler extends DuskConfig {
+    public static HashMap<String, List<String>> configMetaData = new HashMap<String, List<String>>();
+
+    @Entry public static String elytraEnchantmentList = "\"\"";
+
+    public static void initConfig() {
+        configMetaData.put("elytraEnchantmentList", Arrays.asList(
+                "Add enchantments for the elytra dropped by dragons to have, for example: \"vanishing_curse:1, unbreaking:3\""
+        ));
+
+        DuskConfig.init(Reference.NAME, Reference.MOD_ID, ConfigHandler.class);
+    }
+}

--- a/Common/src/main/java/com/natamus/dragondropselytra/events/DragonEvent.java
+++ b/Common/src/main/java/com/natamus/dragondropselytra/events/DragonEvent.java
@@ -1,8 +1,13 @@
 package com.natamus.dragondropselytra.events;
 
 import com.natamus.collective.functions.MessageFunctions;
+import com.natamus.dragondropselytra.config.ConfigHandler;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
@@ -10,10 +15,12 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class DragonEvent {
 	public static void mobItemDrop(Level world, Entity entity, DamageSource damageSource) {
@@ -45,6 +52,21 @@ public class DragonEvent {
 		MessageFunctions.broadcastMessage(world, "It seems like the slain Ender Dragon dropped an elytra! Perhaps it previously belonged to another adventurer?", ChatFormatting.DARK_GREEN);
 		
 		ItemStack elytrastack = new ItemStack(Items.ELYTRA, 1);
+
+		String noSpaceEnchantList = ConfigHandler.elytraEnchantmentList.replaceAll(" ", "");
+		final Pattern regexPattern = Pattern.compile("^[\\w]+:[\\d]+(,[\\w]+:[\\d]+)*$", Pattern.CASE_INSENSITIVE);
+		boolean configCorrectFormat = regexPattern.matcher(noSpaceEnchantList).matches();
+
+		if(!noSpaceEnchantList.isEmpty() & configCorrectFormat) {
+			HolderLookup.RegistryLookup<Enchantment> lookup = world.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+			String[] configEnchants = noSpaceEnchantList.split(",");
+			for (String enchantBundle : configEnchants) {
+				String enchant = enchantBundle.split(":")[0];
+				int power = Integer.parseInt(enchantBundle.split(":")[1]);
+				elytrastack.enchant(lookup.getOrThrow(ResourceKey.create(Registries.ENCHANTMENT, ResourceLocation.withDefaultNamespace(enchant))), power);
+			}
+		}
+
 		if (player == null) {
 			ItemEntity elytra = new ItemEntity(world, epos.getX(), epos.getY()+1, epos.getZ(), elytrastack);
 			world.addFreshEntity(elytra);

--- a/Fabric/src/main/java/com/natamus/dragondropselytra/fabric/config/IntegrateModMenu.java
+++ b/Fabric/src/main/java/com/natamus/dragondropselytra/fabric/config/IntegrateModMenu.java
@@ -1,0 +1,13 @@
+package com.natamus.dragondropselytra.fabric.config;
+
+import com.natamus.collective.config.DuskConfig;
+import com.natamus.dragondropselytra.util.Reference;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+
+public class IntegrateModMenu implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> DuskConfig.DuskConfigScreen.getScreen(parent, Reference.MOD_ID);
+    }
+}

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
   "icon": "icon.png",
 
   "environment": "*",
-  "entrypoints": { "main": [ "com.natamus.dragondropselytra.ModFabric" ] },
+  "entrypoints": { "main": [ "com.natamus.dragondropselytra.ModFabric" ], "modmenu": [ "com.natamus.dragondropselytra.fabric.config.IntegrateModMenu" ] },
 
   "depends": {
     "fabricloader": ">=0.15.0",

--- a/Forge/src/main/java/com/natamus/dragondropselytra/ModForge.java
+++ b/Forge/src/main/java/com/natamus/dragondropselytra/ModForge.java
@@ -2,6 +2,7 @@ package com.natamus.dragondropselytra;
 
 import com.natamus.collective.check.RegisterMod;
 import com.natamus.collective.check.ShouldLoadCheck;
+import com.natamus.dragondropselytra.forge.config.IntegrateForgeConfig;
 import com.natamus.dragondropselytra.forge.events.ForgeDragonEvent;
 import com.natamus.dragondropselytra.util.Reference;
 import net.minecraftforge.common.MinecraftForge;
@@ -23,6 +24,8 @@ public class ModForge {
 
 		setGlobalConstants();
 		ModCommon.init();
+
+		IntegrateForgeConfig.registerScreen(modLoadingContext);
 
 		RegisterMod.register(Reference.NAME, Reference.MOD_ID, Reference.VERSION, Reference.ACCEPTED_VERSIONS);
 	}

--- a/Forge/src/main/java/com/natamus/dragondropselytra/forge/config/IntegrateForgeConfig.java
+++ b/Forge/src/main/java/com/natamus/dragondropselytra/forge/config/IntegrateForgeConfig.java
@@ -1,0 +1,16 @@
+package com.natamus.dragondropselytra.forge.config;
+
+import com.natamus.collective.config.DuskConfig;
+import com.natamus.dragondropselytra.util.Reference;
+import net.minecraftforge.client.ConfigScreenHandler;
+import net.minecraftforge.fml.ModLoadingContext;
+
+public class IntegrateForgeConfig {
+    public static void registerScreen(ModLoadingContext modLoadingContext) {
+        modLoadingContext.registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class, () -> {
+            return new ConfigScreenHandler.ConfigScreenFactory((mc, screen) -> {
+                return DuskConfig.DuskConfigScreen.getScreen(screen, Reference.MOD_ID);
+            });
+        });
+    }
+}

--- a/NeoForge/src/main/java/com/natamus/dragondropselytra/ModNeoForge.java
+++ b/NeoForge/src/main/java/com/natamus/dragondropselytra/ModNeoForge.java
@@ -2,10 +2,12 @@ package com.natamus.dragondropselytra;
 
 import com.natamus.collective.check.RegisterMod;
 import com.natamus.collective.check.ShouldLoadCheck;
+import com.natamus.dragondropselytra.neoforge.config.IntegrateNeoForgeConfig;
 import com.natamus.dragondropselytra.neoforge.events.NeoForgeDragonEvent;
 import com.natamus.dragondropselytra.util.Reference;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 
@@ -21,6 +23,8 @@ public class ModNeoForge {
 
 		setGlobalConstants();
 		ModCommon.init();
+
+		IntegrateNeoForgeConfig.registerScreen(ModLoadingContext.get());
 
 		RegisterMod.register(Reference.NAME, Reference.MOD_ID, Reference.VERSION, Reference.ACCEPTED_VERSIONS);
 	}

--- a/NeoForge/src/main/java/com/natamus/dragondropselytra/neoforge/config/IntegrateNeoForgeConfig.java
+++ b/NeoForge/src/main/java/com/natamus/dragondropselytra/neoforge/config/IntegrateNeoForgeConfig.java
@@ -1,0 +1,20 @@
+package com.natamus.dragondropselytra.neoforge.config;
+
+import com.natamus.dragondropselytra.util.Reference;
+import com.natamus.collective.config.DuskConfig;
+import net.minecraft.client.gui.screens.Screen;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModLoadingContext;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class IntegrateNeoForgeConfig {
+    public static void registerScreen(ModLoadingContext modLoadingContext) {
+        modLoadingContext.registerExtensionPoint(IConfigScreenFactory.class, () -> new IConfigScreenFactory() {
+            @Override
+            public @NotNull Screen createScreen(@NotNull ModContainer modContainer, @NotNull Screen screen) {
+                return DuskConfig.DuskConfigScreen.getScreen(screen, Reference.MOD_ID);
+            }
+        });
+    }
+}


### PR DESCRIPTION
A list of enchantments can now optionally be added to customize the elytra that the dragon drops.

as per [#2865](https://github.com/Serilum/.issue-tracker/issues/2865)  

Example config ```dragondropselytra.json5```:
```json5
{
	// Add enchantments for the elytra dropped by dragons to have, for example: "vanishing_curse:1, unbreaking:3"
	"elytraEnchantmentList": "vanishing_curse:1, binding_curse:1"
}